### PR TITLE
add powdr riscv rt

### DIFF
--- a/guest-powdr/Cargo.toml
+++ b/guest-powdr/Cargo.toml
@@ -6,10 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# powdr = { git = "https://github.com/powdr-labs/powdr", branch = "continuations-data-input" }
 zeth-lib = { path = "../lib", default-features = false }
 zeth-primitives = { path = "../primitives", features = ["revm"] }
 revm = { git = "https://github.com/powdr-labs/revm", branch = "serde-no-std", default-features = false, features = [ "serde" ] }
 ruint = { version = "1.10", default-features = false }
+powdr_riscv_rt = { git = "https://github.com/powdr-labs/powdr", branch = "continuations-data-input" }
+
+# TODO: we need to add this for compatibility reasons until we're able to update the nightly we use for riscv compilation
+ahash = { version = "=0.8.6", default-features = false }
 
 [workspace]


### PR DESCRIPTION
~The one change that whoever is running `bin-powdr` needs to do is to make sure that Rust nightly-2023-10-05 is installed (instead of 2023-01-03) because I've updated that in the powdr branch we use here. This is needed for some compatibility problems in `ahash`, but it's good to update it anyway since they added some more support to RISCV.~

The above will be true once we manage to update the nightly version we use for RISCV compilation. For now I've added the `ahash` workaround.